### PR TITLE
Reject a promise if fortune responded with error

### DIFF
--- a/lib/crud-factory.js
+++ b/lib/crud-factory.js
@@ -29,7 +29,7 @@ module.exports = function(app, resources,actionNames){
     return function(cb){
       var dispatch = function(){
         return app[method](resource, request).then(function(result) {
-          if(result && result.error) throw new Error(result.detail);
+          if(result && result.error) throw new Error(result.detail || result.error);
           return result;
         });
       };

--- a/lib/crud-factory.js
+++ b/lib/crud-factory.js
@@ -28,7 +28,10 @@ module.exports = function(app, resources,actionNames){
     options = options || {};
     return function(cb){
       var dispatch = function(){
-        return app[method](resource, request);
+        return app[method](resource, request).then(function(result) {
+          if(result && result.error) throw new Error(result.detail);
+          return result;
+        });
       };
 
       if(!cb){

--- a/lib/fortune-client.js
+++ b/lib/fortune-client.js
@@ -42,7 +42,7 @@ module.exports = function(apps){
           router.registerResources(remoteAdapter(app), resources);
 
           return self.resources = _.union(self.resources, resources);
-        }).catch(function(err) { console.trace(err) });
+        });
       }else{
         throw new Error("App must be a function or an object, got " + typeof app);
       }

--- a/test/unit/crud-factory.js
+++ b/test/unit/crud-factory.js
@@ -43,7 +43,7 @@ module.exports = function(util){
             query: {}
           }).should.be.true;
           done();
-        });
+        }).catch(done);
       });
 
       it("gets a collection of documents", function(done){
@@ -54,7 +54,7 @@ module.exports = function(util){
             params: {}
           }).should.be.true;
           done();
-        });
+        }).catch(done);
       });
 
       it("creates a document", function(done){
@@ -66,7 +66,7 @@ module.exports = function(util){
             params: {}
           }).should.be.true;
           done();
-        }).catch(function(err){ console.trace(err); });
+        }).catch(done);
       });
 
       it("destroys a document", function(done){
@@ -77,7 +77,7 @@ module.exports = function(util){
             query: {}
           }).should.be.true;
           done();
-        });
+        }).catch(done);
       });
 
       it("replaces a document", function(done){
@@ -89,7 +89,7 @@ module.exports = function(util){
             query: {}
           }).should.be.true;
           done();
-        });
+        }).catch(done);
       });
 
       it("updates a document", function(done){
@@ -101,7 +101,7 @@ module.exports = function(util){
             query: {}
           }).should.be.true;
           done();
-        });
+        }).catch(done);
       });
 
       it("passes auth credentials", function(done){
@@ -114,7 +114,7 @@ module.exports = function(util){
             }
           }).should.be.true;
           done();
-        });
+        }).catch(done);
       });
 
       it("merges collection query into the request query filters", function(){
@@ -138,7 +138,7 @@ module.exports = function(util){
               query: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
         });
 
         it("gets a collection of documents", function(done){
@@ -149,7 +149,7 @@ module.exports = function(util){
               params: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
         });
 
         it("creates a document", function(done){
@@ -161,7 +161,7 @@ module.exports = function(util){
               params: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
         });
 
         it("destroys a document", function(done){
@@ -172,7 +172,7 @@ module.exports = function(util){
               query: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
         });
 
         it("replaces a document", function(done){
@@ -184,7 +184,7 @@ module.exports = function(util){
               query: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
         });
 
         it("updates a document", function(done){
@@ -196,7 +196,7 @@ module.exports = function(util){
               query: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
         });
 
         it("merges collection query into the request query filters", function(){
@@ -232,7 +232,7 @@ module.exports = function(util){
               query: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
         });
 
         it("gets a collection of documents", function(done){
@@ -243,7 +243,7 @@ module.exports = function(util){
               params: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
         });
 
         it("creates a document", function(done){
@@ -255,7 +255,7 @@ module.exports = function(util){
               params: {}
             }).should.be.true;
             done();
-          }).catch(function(err){ console.trace(err); });
+          }).catch(done);
         });
 
         it("destroys a document", function(done){
@@ -266,7 +266,7 @@ module.exports = function(util){
               query: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
         });
 
         it("replaces a document", function(done){
@@ -278,7 +278,7 @@ module.exports = function(util){
               query: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
         });
 
         it("updates a document", function(done){
@@ -290,7 +290,16 @@ module.exports = function(util){
               query: {}
             }).should.be.true;
             done();
-          });
+          }).catch(done);
+        });
+      });
+      it("rejects a promise if error returned", function(done) {
+        fortune.direct.get.returns(when.resolve({ error: "Something wrong happened", detail: "MongoError: database not found" }));
+        crud.fancy.getResource(0,{opts:true})().then(function(){
+          done(new Error("Promise with error should be rejected"));
+        }).catch(function(error) {
+          error.message.should.eql("MongoError: database not found");
+          done();
         });
       });
     });

--- a/test/unit/crud-factory.js
+++ b/test/unit/crud-factory.js
@@ -302,6 +302,15 @@ module.exports = function(util){
           done();
         });
       });
+      it("rejects a promise with main error if detail is absent", function(done) {
+        fortune.direct.get.returns(when.resolve({ error: "Something wrong happened" }));
+        crud.fancy.getResource(0,{opts:true})().then(function(){
+          done(new Error("Promise with error should be rejected"));
+        }).catch(function(error) {
+          error.message.should.eql("Something wrong happened");
+          done();
+        }).catch(done);
+      });
     });
   });
 };


### PR DESCRIPTION
This is expected behavior from any promise. Users should not check for an error in `then` handler (and as real usage shows, they never do).